### PR TITLE
Updated the misspell in average_precision

### DIFF
--- a/code/classification/run_classifier.py
+++ b/code/classification/run_classifier.py
@@ -11,7 +11,7 @@ Created on Wed Sep 29 14:23:48 2021
 import argparse, pickle
 from sklearn.dummy import DummyClassifier
 
-from sklearn.metrics import accuracy_score, cohen_kappa_score, f1_score, average_precision, precision_recall_curve
+from sklearn.metrics import accuracy_score, cohen_kappa_score, f1_score, average_precision_score, precision_recall_curve
 
 
 # setting up CLI


### PR DESCRIPTION
I have change "Average_precision" to "Average_precision_score" while importing the package from sklearn.